### PR TITLE
Fix bug: send stale cmd; learner read wait infinitely;

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -213,7 +213,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     );
     SocketAddr::from_str(&server_cfg.engine_addr)
         .unwrap_or_else(|e| fatal!("failed to parser engine server address: {:?}", e));
-    engines.set_engine_client(
+    engines.set_engine_client_cfg(
         env.clone(),
         security_mgr.clone(),
         server_cfg.engine_addr.clone(),

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -956,7 +956,7 @@ impl Engines {
         }
     }
 
-    pub fn set_engine_client(
+    pub fn set_engine_client_cfg(
         &mut self,
         env: Arc<Environment>,
         security_mgr: Arc<SecurityManager>,
@@ -969,7 +969,7 @@ impl Engines {
         });
     }
 
-    pub fn engine_client(&self) -> EngineClient {
+    pub fn create_engine_client(&self) -> EngineClient {
         const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: i32 = 2 * 1024 * 1024;
 
         let cfg = self.engine_client_cfg.as_ref().unwrap();

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -904,8 +904,8 @@ impl ApplyDelegate {
             ctx.wb_mut().rollback_to_save_point().unwrap();
             success = false;
             match e {
-                Error::StaleEpoch(..) => debug!("{} stale epoch err: {:?}", self.tag, e),
-                _ => error!("{} execute raft command err: {:?}", self.tag, e),
+                Error::StaleEpoch(..) => panic!("{} stale epoch err: {:?}", self.tag, e),
+                _ => panic!("{} execute raft command err: {:?}", self.tag, e),
             }
             (cmd_resp::new_error(e), None)
         });
@@ -1802,7 +1802,6 @@ impl ApplyDelegate {
                     self.handle_delete_range(req, &mut ranges, ctx.use_delete_range)
                 }
                 CmdType::IngestSST => {
-                    let _ = self.handle_ingest_sst(ctx, req, &mut ssts);
                     panic!("CmdType::IngestSST is not supported");
                 }
                 // Readonly commands are handled in raftstore directly.

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -638,7 +638,7 @@ impl Runner {
                 .thread_count(GENERATE_POOL_SIZE)
                 .build(),
             ctx: SnapContext {
-                engine_client: Arc::new(engines.engine_client()),
+                engine_client: Arc::new(engines.create_engine_client()),
                 engines,
                 mgr,
                 batch_size,


### PR DESCRIPTION
- send empty cmd at first to make engine report all region states

- make `exec_compact_log` always return OK

- make apply_raft_cmd panic if meet error