### PR TITLE
Hard-code label to have hidden 'engine=tiflash' attribute

### DIFF
--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -329,7 +329,7 @@ pub fn check_term(req: &RaftCmdRequest, term: u64) -> Result<()> {
     if header.get_term() == 0 || term <= header.get_term() + 1 {
         Ok(())
     } else {
-        // If header's term is 2 verions behind current term,
+        // If header's term is 2 versions behind current term,
         // leadership may have been changed away.
         Err(Error::StaleCommand)
     }

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1155,14 +1155,14 @@ impl ApplyDelegate {
 
         match change_type {
             ConfChangeType::AddNode => {
-                let add_ndoe_fp = || {
+                let add_node_fp = || {
                     fail_point!(
                         "apply_on_add_node_1_2",
                         { self.id == 2 && self.region_id() == 1 },
                         |_| {}
                     )
                 };
-                add_ndoe_fp();
+                add_node_fp();
 
                 PEER_ADMIN_CMD_COUNTER_VEC
                     .with_label_values(&["add_peer", "all"])

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -21,6 +21,7 @@ use util::config::{self, ReadableDuration, ReadableSize};
 use util::io_limiter::DEFAULT_SNAP_MAX_BYTES_PER_SEC;
 
 pub use raftstore::store::Config as RaftStoreConfig;
+use std::borrow::ToOwned;
 pub use storage::Config as StorageConfig;
 
 pub const DEFAULT_CLUSTER_ID: u64 = 0;
@@ -210,8 +211,18 @@ impl Config {
             validate_label(v, "value")?;
         }
 
-        if !self.labels.contains_key("engine")
-            || self.labels.get(&"engine".to_owned()).unwrap() != "tiflash"
+        if !self
+            .labels
+            .contains_key(&DEFAULT_ENGINE_LABEL_KEY.to_owned())
+        {
+            self.labels.insert(
+                DEFAULT_ENGINE_LABEL_KEY.to_owned(),
+                DEFAULT_ENGINE_LABEL_VALUE.to_owned(),
+            );
+        } else if self
+            .labels
+            .get(&DEFAULT_ENGINE_LABEL_KEY.to_owned())
+            .unwrap() != DEFAULT_ENGINE_LABEL_VALUE
         {
             return Err(box_err!(
                 "server.labels should not contain any label with key 'engine'."


### PR DESCRIPTION
Since TiDB/PD has already hard-coded label for tiflash to `engine=tiflash`, we should also hardcode in rngine so that it will not confuse users to set extra configurations.