### PR TITLE
cdc: Fix resolve ts panic when rolling back not-existing transactions

### DIFF
--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -7,5 +7,5 @@ mod util;
 
 pub use self::point_getter::{PointGetter, PointGetterBuilder};
 pub use self::reader::MvccReader;
-pub use self::scanner::{tests, EntryScanner};
+pub use self::scanner::{txn_entry_tests, EntryScanner};
 pub use self::scanner::{Scanner, ScannerBuilder};

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -17,7 +17,7 @@ use crate::storage::{
 use self::backward::BackwardScanner;
 pub use self::delta::DeltaScanner;
 use self::forward::ForwardScanner;
-pub use self::txn_entry::{tests, Scanner as EntryScanner};
+pub use self::txn_entry::{tests as txn_entry_tests, Scanner as EntryScanner};
 
 /// `Scanner` factory.
 pub struct ScannerBuilder<S: Snapshot>(ScannerConfig<S>);


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Rollback may happen on a not-existing transaction, and it will trigger untrack_lock. However untrack_lock assumes that there must be a tracked transaction to rollback and did such a incorrect assertion. Fix it.

Merging to overvenus/tikv, cdc branch

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

By unit test.

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
