### PR TITLE
cdc: Fix potential panic on late arriving commit

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -222,6 +222,18 @@ fn test_cdc_basic() {
 
     // Commit
     let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut counter = 0;
+    loop {
+        let event = receive_event(true);
+        // Even if there is no write,
+        // resolved ts should be advanced regularly.
+        if let Event_oneof_event::ResolvedTs(_) = event {
+            counter += 1;
+            if counter > 5 {
+                break;
+            }
+        }
+    }
     suite.must_kv_commit(vec![k.clone().into_bytes()], start_ts, commit_ts);
     let event = receive_event(false);
     match event {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

In the resolved_ts module, the logic of calculating `min_ts` keeps advancing it to newest tso from pd. Then when untracking lock, it asserts `commit_ts` > `min_ts`. However if a commit_ts arrives late because of slow network, TiKV may panic. This PR fixes it.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

By integration test
