### PR TITLE
cdc: Fix panic when on_region_ready invoked after region is deregistered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "engine",
  "engine_rocks",
  "engine_traits",
+ "fail",
  "failure",
  "futures 0.1.29",
  "grpcio",
@@ -3928,6 +3929,7 @@ version = "0.0.1"
 dependencies = [
  "arrow",
  "byteorder 1.3.2",
+ "cdc",
  "configuration",
  "crc32fast",
  "crc64fast",

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -29,6 +29,7 @@ engine_rocks = { path = "../engine_rocks" }
 engine_traits = { path = "../engine_traits" }
 txn_types = { path = "../txn_types" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
+fail = "0.3"
 
 [dependencies.prometheus]
 version = "0.4.2"

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -617,7 +617,4 @@ mod tests {
 
         worker.stop().unwrap().join().unwrap();
     }
-
-    #[test]
-    fn test_region_ready_after_deregistering() {}
 }

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -4,6 +4,8 @@
 extern crate slog_global;
 #[macro_use]
 extern crate failure;
+#[macro_use(fail_point)]
+extern crate fail;
 
 mod delegate;
 mod endpoint;

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -496,9 +496,6 @@ fn test_cdc_stale_epoch_after_region_ready() {
 }
 
 #[test]
-fn test_region_ready_after_deregistering() {}
-
-#[test]
 fn test_cdc_scan() {
     let mut suite = TestSuite::new(1);
 

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -97,7 +97,7 @@ impl TestSuite {
 
     fn stop(mut self) {
         for (_, mut worker) in self.endpoints {
-            worker.stop().unwrap();
+            worker.stop().unwrap().join().unwrap();
         }
         self.cluster.shutdown();
     }
@@ -494,6 +494,9 @@ fn test_cdc_stale_epoch_after_region_ready() {
     event_feed_wrap.replace(None);
     suite.stop();
 }
+
+#[test]
+fn test_region_ready_after_deregistering() {}
 
 #[test]
 fn test_cdc_scan() {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -58,6 +58,7 @@ crossbeam = "0.7.2"
 configuration = { path = "../components/configuration" }
 engine = { path = "../components/engine" }
 txn_types = { path = "../components/txn_types" }
+cdc = { path = "../components/cdc" }
 futures = "0.1"
 futures-cpupool = "0.1"
 futures03 = { package = "futures", version = "0.3", features = ["executor"] }

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 mod test_bootstrap;
+mod test_cdc;
 mod test_conf_change;
 mod test_coprocessor;
 mod test_gc_worker;

--- a/tests/failpoints/cases/test_cdc.rs
+++ b/tests/failpoints/cases/test_cdc.rs
@@ -1,0 +1,110 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::cell::Cell;
+use std::sync::*;
+use std::time::Duration;
+
+use futures::{Future, Stream};
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::cdcpb::*;
+use raft::StateRole;
+use test_raftstore::*;
+use tikv::raftstore::coprocessor::RoleObserver;
+use tikv::raftstore::coprocessor::{CoprocessorHost, ObserverContext};
+use tikv_util::worker::Worker;
+use tikv_util::HandyRwLock;
+
+use cdc::{CdcObserver, Endpoint};
+
+#[test]
+fn test_region_ready_after_deregister() {
+    // Prepare the cluster
+    // TODO: Code duplicated with components/cdc/tests
+    let mut cluster = new_server_cluster(1, 1);
+
+    let id = 1;
+
+    let pd_cli = cluster.pd_client.clone();
+    // Create and run cdc endpoints.
+    let mut worker = Worker::new(format!("cdc-{}", id));
+    let mut sim = cluster.sim.wl();
+
+    // Register cdc service to gRPC server.
+    let scheduler = worker.scheduler();
+    sim.pending_services
+        .entry(id)
+        .or_default()
+        .push(Box::new(move || {
+            create_change_data(cdc::Service::new(scheduler.clone()))
+        }));
+    let scheduler = worker.scheduler();
+    let cdc_ob = CdcObserver::new(scheduler.clone());
+    let cdc_ob1 = cdc_ob.clone();
+    sim.coprocessor_hooks.entry(id).or_default().push(Box::new(
+        move |host: &mut CoprocessorHost| {
+            host.registry
+                .register_cmd_observer(100, Box::new(cdc_ob1.clone()) as _);
+            host.registry
+                .register_role_observer(100, Box::new(cdc_ob1.clone()) as _);
+        },
+    ));
+    // Unlock sim.
+    drop(sim);
+
+    cluster.run();
+
+    let apply_router = (*cluster.sim.rl()).get_apply_router(id);
+    let cdc_endpoint = Endpoint::new(
+        pd_cli.clone(),
+        worker.scheduler(),
+        apply_router,
+        cdc_ob.clone(),
+    );
+    worker.start(cdc_endpoint).unwrap();
+    let region = cluster.get_region(&[]);
+    let leader = cluster.leader_of_region(region.get_id()).unwrap();
+    let leader_addr = cluster.sim.rl().get_addr(leader.get_store_id()).to_owned();
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env.clone()).connect(&leader_addr);
+    let cdc_cli = ChangeDataClient::new(channel);
+
+    let fp = "cdc_incremental_scan_start";
+    fail::cfg(fp, "pause").unwrap();
+
+    let mut req = ChangeDataRequest::default();
+    req.region_id = 1;
+    req.set_region_epoch(region.get_region_epoch().clone());
+    let event_feed = cdc_cli.event_feed(&req).unwrap();
+    // Sleep for a while to make sure the region has been subscribed
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Simulate a role change event
+    let mut context = ObserverContext::new(&region);
+    cdc_ob.on_role_change(&mut context, StateRole::Follower);
+
+    // Then CDC should not panic
+    fail::remove(fp);
+
+    let event_feed_wrap = Cell::new(Some(event_feed));
+    let receive_event = |keep_resolved_ts: bool| loop {
+        let (change_data, events) =
+            match event_feed_wrap.replace(None).unwrap().into_future().wait() {
+                Ok(res) => res,
+                Err(e) => panic!("receive failed {:?}", e.0),
+            };
+        event_feed_wrap.set(Some(events));
+        let mut change_data = change_data.unwrap();
+        assert_eq!(change_data.events.len(), 1);
+        let change_data_event = &mut change_data.events[0];
+        let event = change_data_event.event.take().unwrap();
+        match event {
+            Event_oneof_event::ResolvedTs(_) if !keep_resolved_ts => continue,
+            other => return other,
+        }
+    };
+
+    receive_event(false);
+
+    worker.stop().unwrap().join().unwrap();
+    cluster.shutdown();
+}


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix panic when on_region_ready invoked after region is deregistered

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

